### PR TITLE
IntelliJ-based IDEs now support ligatures

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,7 +59,7 @@ Monoid uses `calt` and Monoisome uses `calt` + `liga` which aren't supported by 
 
 | Working | Partly Working | Not Working |
 |:---|:---|:---|
-| Atom, Brackets, Coda, Eclipse, gEdit, Smultron, Terminal, UltraEdit, Xcode | Visual Studio¹, MacVim³ | gVim, IntelliJ-based², libvte-based, Notepad++, Sublime, TextXterm, Urxvt |
+| Atom, Brackets, Coda, Eclipse, gEdit, IntelliJ-based², Smultron, Terminal, UltraEdit, Xcode | Visual Studio¹, MacVim³ | gVim, libvte-based, Notepad++, Sublime, TextXterm, Urxvt |
 ¹ Ligatures with hyphens doesn't work  
 ² PHPStorm, WebStorm etc.  
 ³ MacVim [snapshot-78](https://github.com/macvim-dev/macvim/releases/tag/snapshot-78), also see the PR [here](https://github.com/macvim-dev/macvim/pull/56)  


### PR DESCRIPTION
IntelliJ-based IDEs now support ligatures:

> We've added support for monospace font ligatures.

https://www.jetbrains.com/idea/whatsnew/#v2016-2-user-interface